### PR TITLE
Bug: 고민 작성 페이지 제출 버그 해결

### DIFF
--- a/gomintapa/lib/src/screens/post/create_post.dart
+++ b/gomintapa/lib/src/screens/post/create_post.dart
@@ -123,21 +123,22 @@ class _CreatePostState extends State<CreatePost> {
     );
   }
 
-  void _submitPost() async {
-    final result = await feedController.feedCreate(
-      _titleController.text,
-      _contentController.text,
-      _aInputController.text,
-      _bInputController.text,
-      _keywordController.text,
-    );
-
+  void _submitPost() {
     handleSubmitPost(
       context: context,
       title: _titleController.text,
       content: _contentController.text,
       aInput: _aInputController.text,
       bInput: _bInputController.text,
+      onSubmit: () async {
+        await feedController.feedCreate(
+          _titleController.text,
+          _contentController.text,
+          _aInputController.text,
+          _bInputController.text,
+          _keywordController.text,
+        );
+      },
     );
   }
 

--- a/gomintapa/lib/src/utils/dialogs/post_submission_util.dart
+++ b/gomintapa/lib/src/utils/dialogs/post_submission_util.dart
@@ -10,7 +10,8 @@ void handleSubmitPost({
   required String content,
   required String aInput,
   required String bInput,
-}) {
+  required Function onSubmit, // 제출 로직을 함수로 전달받음
+}) async {
   // 제목, 내용, A입력, B입력이 모두 비어있지 않은지 확인
   if (!areFieldsNotEmpty(
     title: title,
@@ -22,6 +23,9 @@ void handleSubmitPost({
     showErrorDialog(context, '모든 필드를 입력해 주세요.');
     return;
   }
+
+  // 제출 로직 실행
+  await onSubmit();
 
   // 제출이 완료된 후 이전 화면으로 돌아가기
   Navigator.pop(context);


### PR DESCRIPTION
## 해결 방법
- CreatePost 위젯의 _submitPost 메서드에서 필드 검사를 하고, 모든 필드가 입력되지 않았을 때 제출을 막도록 수정
- handleSubmitPost 함수가 필드 검사를 이미 수행하므로, handleSubmitPost를 호출한 후에만 제출을 진행하도록 feedController.feedCreate를 호출하는 순서를 변경


## 수정 부분 설명
### 1. 필드 검사와 제출 로직의 중복 제거
- 수정 전에는 필드 검사(areFieldsNotEmpty)와 오류 메시지 표시(showErrorDialog)가 handleSubmitPost에서, 실제 제출 로직(feedController.feedCreate)이 _submitPost에서 수행
- 수정 후에는 필드 검사와 제출 로직을 모두 handleSubmitPost 함수에서 수행하도록 변경.  _submitPost 메서드는 handleSubmitPost 함수에 실제 제출 로직을 전달하여 호출

### 2. _submitPost과 handleSubmitPost 역할 분리
- 수정 전에는 handleSubmitPost가 필드 검사를 한 후 이전 화면으로 돌아가는 역할만 하고, _submitPost가 실제 제출 로직을 처리
- 수정 후에는 handleSubmitPost가 필드 검사, 제출 로직 실행, 이전 화면으로 돌아가는 역할을 모두 처리. _submitPost는 단순히 handleSubmitPost를 호출하며, 필요한 데이터를 전달하는 역할.

### 3. 비동기 함수로 변경
- 수정 후 handleSubmitPost는 비동기 함수로 변경되어, 실제 제출 로직(onSubmit 함수)을 await로 기다림. 제출 로직이 완료된 후에만 이전 화면으로 이동.

