### PR TITLE
UI: 피드 화면의 상단 하단 고정 영역 제거

### DIFF
--- a/gomintapa/lib/src/screens/feed/feed_index.dart
+++ b/gomintapa/lib/src/screens/feed/feed_index.dart
@@ -63,48 +63,49 @@ class _FeedIndexState extends State<FeedIndex> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Column(
+      body: Stack(
         children: [
-          Container(
-            color: Colors.white, // 배경색
-            child: Column(
-              children: [
-                // 필터 버튼과 선택된 키워드를 표시하는 섹션
-                FilterBarSection(
+          Column(
+            children: [
+              Container(
+                color: Colors.white, // 배경색
+                child: FilterBarSection(
+                  // 필터 버튼과 선택된 키워드를 표시하는 섹션
                   onFilterPressed: _showKeywordModal, // 버튼 클릭 시 필터 모달 표시
                   selectedKeywords: _selectedKeywords, // 현재 선택된 키워드 전달
                   onKeywordRemoved: _removeKeyword, // 키워드 삭제 콜백 함수
                 ),
-              ],
-            ),
-          ),
-          const SizedBox(height: 30),
-
-          Expanded(
-            child: Obx(
-              () => NotificationListener<ScrollNotification>(
-                onNotification: _onNotification,
-                child: RefreshIndicator(
-                  onRefresh: _onRefresh,
-                  child: ListView.builder(
-                    itemCount: feedController.feedList.length,
-                    itemBuilder: (context, index) {
-                      final item = feedController.feedList[index];
-                      return ConcernListItem(item);
-                    },
+              ),
+              Expanded(
+                child: Obx(
+                  () => NotificationListener<ScrollNotification>(
+                    onNotification: _onNotification,
+                    child: RefreshIndicator(
+                      onRefresh: _onRefresh,
+                      child: ListView.builder(
+                        itemCount: feedController.feedList.length,
+                        itemBuilder: (context, index) {
+                          final item = feedController.feedList[index];
+                          return ConcernListItem(item);
+                        },
+                      ),
+                    ),
                   ),
                 ),
               ),
-            ),
+            ],
           ),
           // 하단 중앙에 위치한 '고민 작성' 버튼
-          Align(
-            alignment: Alignment.bottomCenter,
-            child: CreatePostButton(
-              onPressed: () {
-                // 버튼 클릭 시 고민 작성 페이지로 이동
-                Navigator.pushNamed(context, '/create_post');
-              },
+          Positioned(
+            bottom: 20,
+            left: 0,
+            right: 0,
+            child: Center(
+              child: CreatePostButton(
+                onPressed: () {
+                  Navigator.pushNamed(context, '/create_post');
+                },
+              ),
             ),
           ),
         ],

--- a/gomintapa/lib/src/screens/feed/mak_feed_index.dart
+++ b/gomintapa/lib/src/screens/feed/mak_feed_index.dart
@@ -56,43 +56,45 @@ class _MakFeedIndexState extends State<MakFeedIndex> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Column(
+      body: Stack(
         children: [
-          Container(
-            color: Colors.white, // 배경색
-            child: Column(
-              children: [
-                // 필터 버튼과 선택된 키워드를 표시하는 섹션
-                FilterBarSection(
+          Column(
+            children: [
+              Container(
+                color: Colors.white, // 배경색
+                child: FilterBarSection(
                   onFilterPressed: _showKeywordModal, // 버튼 클릭 시 필터 모달 표시
                   selectedKeywords: _selectedKeywords, // 현재 선택된 키워드 전달
                   onKeywordRemoved: _removeKeyword, // 키워드 삭제 콜백 함수
                 ),
-              ],
-            ),
+              ),
+              const SizedBox(height: 30),
+              Expanded(
+                child: ListView(
+                  children: [
+                    MakListItem(
+                        onTap: () => _navigateToMyPage(context)), // 임시 설정
+                    MakListItem(onTap: () => _navigateToMyPage(context)),
+                    MakListItem(onTap: () => _navigateToMyPage(context)),
+                    MakListItem(onTap: () => _navigateToMyPage(context)),
+                    MakListItem(onTap: () => _navigateToMyPage(context)),
+                  ],
+                ),
+              ),
+            ],
           ),
-          const SizedBox(height: 30),
-
-          Expanded(
-            child: ListView(
-              children: [
-                MakListItem(onTap: () => _navigateToMyPage(context)), // 임시 설정
-                MakListItem(onTap: () => _navigateToMyPage(context)),
-                MakListItem(onTap: () => _navigateToMyPage(context)),
-                MakListItem(onTap: () => _navigateToMyPage(context)),
-                MakListItem(onTap: () => _navigateToMyPage(context)),
-              ],
-            ),
-          ),
-          //),
           // 하단 중앙에 위치한 '고민 작성' 버튼
-          Align(
-            alignment: Alignment.bottomCenter,
-            child: CreatePostButton(
-              onPressed: () {
-                // 버튼 클릭 시 고민 작성 페이지로 이동
-                Navigator.pushNamed(context, '/create_post');
-              },
+          Positioned(
+            bottom: 20,
+            left: 0,
+            right: 0,
+            child: Center(
+              child: CreatePostButton(
+                onPressed: () {
+                  // 버튼 클릭 시 고민 작성 페이지로 이동
+                  Navigator.pushNamed(context, '/create_post');
+                },
+              ),
             ),
           ),
         ],

--- a/gomintapa/lib/src/screens/feed/mak_feed_index.dart
+++ b/gomintapa/lib/src/screens/feed/mak_feed_index.dart
@@ -68,7 +68,6 @@ class _MakFeedIndexState extends State<MakFeedIndex> {
                   onKeywordRemoved: _removeKeyword, // 키워드 삭제 콜백 함수
                 ),
               ),
-              const SizedBox(height: 30),
               Expanded(
                 child: ListView(
                   children: [

--- a/gomintapa/lib/src/screens/feed/tang_feed_index.dart
+++ b/gomintapa/lib/src/screens/feed/tang_feed_index.dart
@@ -68,7 +68,6 @@ class _TangFeedIndexState extends State<TangFeedIndex> {
                   onKeywordRemoved: _removeKeyword, // 키워드 삭제 콜백 함수
                 ),
               ),
-              const SizedBox(height: 30),
               Expanded(
                 child: ListView(
                   children: [

--- a/gomintapa/lib/src/screens/feed/tang_feed_index.dart
+++ b/gomintapa/lib/src/screens/feed/tang_feed_index.dart
@@ -56,58 +56,59 @@ class _TangFeedIndexState extends State<TangFeedIndex> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Column(
+      body: Stack(
         children: [
-          Container(
-            color: Colors.white, // 배경색
-            child: Column(
-              children: [
-                // 필터 버튼과 선택된 키워드를 표시하는 섹션
-                FilterBarSection(
+          Column(
+            children: [
+              Container(
+                color: Colors.white, // 배경색
+                child: FilterBarSection(
                   onFilterPressed: _showKeywordModal, // 필터 버튼 클릭 시 필터 모달 표시
                   selectedKeywords: _selectedKeywords, // 현재 선택된 키워드 전달
                   onKeywordRemoved: _removeKeyword, // 키워드 삭제 콜백 함수
                 ),
-              ],
-            ),
+              ),
+              const SizedBox(height: 30),
+              Expanded(
+                child: ListView(
+                  children: [
+                    TangListItem(
+                      onTap: () => _navigateToMyPage(context),
+                      isOption1Winner: true, // 첫 번째 옵션이 이긴 경우
+                      isOption2Winner: false,
+                    ),
+                    TangListItem(
+                      onTap: () => _navigateToMyPage(context),
+                      isOption1Winner: false, // 두 번째 옵션이 이긴 경우
+                      isOption2Winner: true,
+                    ),
+                    TangListItem(
+                      onTap: () => _navigateToMyPage(context),
+                      isOption1Winner: true, // 첫 번째 옵션이 이긴 경우
+                      isOption2Winner: false,
+                    ),
+                    TangListItem(
+                      onTap: () => _navigateToMyPage(context),
+                      isOption1Winner: false, // 두 번째 옵션이 이긴 경우
+                      isOption2Winner: true,
+                    ),
+                  ],
+                ),
+              ),
+            ],
           ),
-          const SizedBox(height: 30),
-
-          Expanded(
-            child: ListView(
-              children: [
-                TangListItem(
-                  onTap: () => _navigateToMyPage(context),
-                  isOption1Winner: true, // 첫 번째 옵션이 이긴 경우
-                  isOption2Winner: false,
-                ), // 임시 설정
-                TangListItem(
-                  onTap: () => _navigateToMyPage(context),
-                  isOption1Winner: false, // 두 번째 옵션이 이긴 경우
-                  isOption2Winner: true,
-                ),
-                TangListItem(
-                  onTap: () => _navigateToMyPage(context),
-                  isOption1Winner: true, // 첫 번째 옵션이 이긴 경우
-                  isOption2Winner: false,
-                ),
-                TangListItem(
-                  onTap: () => _navigateToMyPage(context),
-                  isOption1Winner: false, // 두 번째 옵션이 이긴 경우
-                  isOption2Winner: true,
-                ),
-              ],
-            ),
-          ),
-          //),
           // 하단 중앙에 위치한 '고민 작성' 버튼
-          Align(
-            alignment: Alignment.bottomCenter,
-            child: CreatePostButton(
-              onPressed: () {
-                // 버튼 클릭 시 고민 작성 페이지로 이동
-                Navigator.pushNamed(context, '/create_post');
-              },
+          Positioned(
+            bottom: 20,
+            left: 0,
+            right: 0,
+            child: Center(
+              child: CreatePostButton(
+                onPressed: () {
+                  // 버튼 클릭 시 고민 작성 페이지로 이동
+                  Navigator.pushNamed(context, '/create_post');
+                },
+              ),
             ),
           ),
         ],

--- a/gomintapa/lib/src/widgets/buttons/create_post_button.dart
+++ b/gomintapa/lib/src/widgets/buttons/create_post_button.dart
@@ -1,34 +1,34 @@
 import 'package:flutter/material.dart';
 
-class CreatePostButton extends StatelessWidget {
+class CreatePostButton extends StatefulWidget {
   final VoidCallback onPressed;
 
   const CreatePostButton({Key? key, required this.onPressed}) : super(key: key);
 
   @override
+  State<CreatePostButton> createState() => _CreatePostButtonState();
+}
+
+class _CreatePostButtonState extends State<CreatePostButton> {
+  bool extended = false;
+
+  @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.all(16.0), // 여백 추가
-      child: ElevatedButton.icon(
-        onPressed: onPressed,
-        icon: Icon(Icons.edit_outlined, color: Colors.red),
-        label: Text(
-          '고민 작성',
-          style: TextStyle(
-            color: Colors.black,
-            fontSize: 14,
-            fontWeight: FontWeight.bold,
-          ),
-        ),
-        style: ElevatedButton.styleFrom(
-          backgroundColor: Colors.white, // 배경색
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(25), // 모서리 둥글기
-          ),
-          padding: EdgeInsets.symmetric(horizontal: 20, vertical: 20), // 패딩
-          elevation: 5, // 그림자 설정
-        ),
-      ),
+    return FloatingActionButton.extended(
+      onPressed: () {
+        if (extended) {
+          widget.onPressed();
+        }
+        setState(() {
+          extended = !extended;
+        });
+      },
+      label: const Text("고민 작성"),
+      isExtended: extended,
+      icon: const Icon(Icons.edit_outlined, color: Colors.red),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(25)),
+      foregroundColor: Colors.black,
+      backgroundColor: Colors.white,
     );
   }
 }

--- a/gomintapa/lib/src/widgets/listitems/concern_list_item.dart
+++ b/gomintapa/lib/src/widgets/listitems/concern_list_item.dart
@@ -15,6 +15,7 @@ class ConcernListItem extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
+        const SizedBox(height: 25), // ConcernListItem들 사이의 간격 추가
         CardSection(
           onTap: () {
             Get.to(() => PostDetail());
@@ -26,7 +27,7 @@ class ConcernListItem extends StatelessWidget {
               CardTopSection(
                 title: item.title,
               ),
-              const SizedBox(height: 20),
+              const SizedBox(height: 10),
               // 선택 항목 영역
               CardBottomSection(
                 option1: item.firstOption,
@@ -35,7 +36,7 @@ class ConcernListItem extends StatelessWidget {
             ],
           ),
         ),
-        const SizedBox(height: 25), // ConcernListItem들 사이의 간격 추가
+        const SizedBox(height: 15), // ConcernListItem들 사이의 간격 추가
       ],
     );
   }

--- a/gomintapa/lib/src/widgets/listitems/concern_list_item.dart
+++ b/gomintapa/lib/src/widgets/listitems/concern_list_item.dart
@@ -36,7 +36,7 @@ class ConcernListItem extends StatelessWidget {
             ],
           ),
         ),
-        const SizedBox(height: 15), // ConcernListItem들 사이의 간격 추가
+        const SizedBox(height: 10), // ConcernListItem들 사이의 간격 추가
       ],
     );
   }

--- a/gomintapa/lib/src/widgets/listitems/mak_list_item.dart
+++ b/gomintapa/lib/src/widgets/listitems/mak_list_item.dart
@@ -13,6 +13,7 @@ class MakListItem extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
+        const SizedBox(height: 25),
         CardSection(
           onTap: onTap, // onTap 콜백 설정
           child: Column(
@@ -54,7 +55,7 @@ class MakListItem extends StatelessWidget {
             ],
           ),
         ),
-        const SizedBox(height: 25), // ConcernListItem들 사이의 간격 추가
+        const SizedBox(height: 10), // ConcernListItem들 사이의 간격 추가
       ],
     );
   }

--- a/gomintapa/lib/src/widgets/listitems/tang_list_item.dart
+++ b/gomintapa/lib/src/widgets/listitems/tang_list_item.dart
@@ -28,6 +28,7 @@ class TangListItem extends StatelessWidget {
 
     return Column(
       children: [
+        const SizedBox(height: 25),
         CardSection(
           onTap: onTap,
           backgroundColor: containerColor, // 배경 색상 전달
@@ -134,7 +135,7 @@ class TangListItem extends StatelessWidget {
             ],
           ),
         ),
-        const SizedBox(height: 25), // ConcernListItem들 사이의 간격 추가
+        const SizedBox(height: 10), // ConcernListItem들 사이의 간격 추가
       ],
     );
   }


### PR DESCRIPTION
## 피드 화면 레이아웃 수정
- Stack 위젯: 전체 레이아웃을 Stack 위젯으로 감싸서 필터와 버튼을 독립적으로 배치
- Column 위젯: 필터와 리스트를 수직으로 배치
- Expanded 위젯: 리스트를 Expanded로 감싸서 남는 공간을 차지하도록 변경
- Positioned 위젯: 버튼을 하단 중앙에 고정하기 위해 사용

## 피드 화면 작성 버튼 수정
- FloatingActionButton 클래스를 사용하여 버튼 수정