### PR TITLE
feat: 상세페이지에서 수정, 삭제, 고민해결 선택할 수 있게 구현

### DIFF
--- a/gomintapa/lib/src/app.dart
+++ b/gomintapa/lib/src/app.dart
@@ -16,6 +16,9 @@ class MyWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GetMaterialApp(
+      theme: ThemeData(
+        scaffoldBackgroundColor: Colors.white,
+      ),
       debugShowCheckedModeBanner: false, // 디버그 배너 삭제
       routes: {
         '/': (context) => Home(),

--- a/gomintapa/lib/src/app.dart
+++ b/gomintapa/lib/src/app.dart
@@ -27,7 +27,8 @@ class MyWidget extends StatelessWidget {
         '/mypage': (context) => Mypage(),
         '/intro': (context) => Login(),
         '/register': (context) => Register(),
-        '/post_detail': (context) => PostDetail(),
+        // GetMaterialApp의 routes에서는 인자를 전달하지 않기 때문에 주석 처리
+        // '/post_detail': (context) => PostDetail(),
       },
       initialRoute: isLogin ? '/' : '/intro',
     );

--- a/gomintapa/lib/src/screens/post/post_detail.dart
+++ b/gomintapa/lib/src/screens/post/post_detail.dart
@@ -10,6 +10,9 @@ class PostDetail extends StatelessWidget {
   // 선택된 키워드를 저장할 변수
   // final List<String> keywords;
 
+  // 현재 게시물이 사용자 작성 게시물인지 여부
+  final bool isUserPost;
+
   // 임시로 설정한 키워드 리스트
   final List<String> keywords = ['여행', '음식', '기타', '바보'];
 
@@ -18,7 +21,7 @@ class PostDetail extends StatelessWidget {
   //   required this.keywords, // 키워드 매개변수 추가
   // }) : super(key: key);
 
-  PostDetail({super.key});
+  PostDetail({super.key, required this.isUserPost});
 
   @override
   Widget build(BuildContext context) {
@@ -30,9 +33,6 @@ class PostDetail extends StatelessWidget {
     final String choiceBText = "선택 항목 B 텍스트";
     final String? imageAPath = 'assets/images/jjanggu.jpg';
     final String? imageBPath = null; // 이미지 경로가 없는 경우
-
-    // 실제로는 로그인한 사용자와 게시물 작성자 정보를 비교하여 설정
-    final bool isUserPost = true;
 
     return Scaffold(
       appBar: BackAppBar(),
@@ -51,7 +51,7 @@ class PostDetail extends StatelessWidget {
                 child: Column(
                   children: [
                     // 프로필 섹션
-                    ProfileSection(isUserPost: isUserPost),
+                    ProfileSection(isUserPost: isUserPost), // 사용자 게시물 여부 전달
                     SizedBox(height: 10),
                     Divider(color: Color(0xffD9D9D9)),
 

--- a/gomintapa/lib/src/screens/post/post_detail.dart
+++ b/gomintapa/lib/src/screens/post/post_detail.dart
@@ -7,7 +7,8 @@ import '../../widgets/sections/display/profile_section.dart';
 import '../../widgets/sections/display/keyword_section.dart';
 
 class PostDetail extends StatelessWidget {
-  // final List<String> keywords; // 선택된 키워드를 저장할 변수
+  // 선택된 키워드를 저장할 변수
+  // final List<String> keywords;
 
   // 임시로 설정한 키워드 리스트
   final List<String> keywords = ['여행', '음식', '기타', '바보'];
@@ -30,6 +31,9 @@ class PostDetail extends StatelessWidget {
     final String? imageAPath = 'assets/images/jjanggu.jpg';
     final String? imageBPath = null; // 이미지 경로가 없는 경우
 
+    // 실제로는 로그인한 사용자와 게시물 작성자 정보를 비교하여 설정
+    final bool isUserPost = true;
+
     return Scaffold(
       appBar: BackAppBar(),
       body: Container(
@@ -47,7 +51,7 @@ class PostDetail extends StatelessWidget {
                 child: Column(
                   children: [
                     // 프로필 섹션
-                    ProfileSection(),
+                    ProfileSection(isUserPost: isUserPost),
                     SizedBox(height: 10),
                     Divider(color: Color(0xffD9D9D9)),
 
@@ -85,6 +89,7 @@ class PostDetail extends StatelessWidget {
                       imagePath: imageBPath,
                       backgroundColor: const Color(0xff5DB1FF),
                     ),
+
                     const SizedBox(height: 10),
                     const Divider(color: Color(0xffD9D9D9)),
                     const SizedBox(height: 10),

--- a/gomintapa/lib/src/screens/post/post_detail.dart
+++ b/gomintapa/lib/src/screens/post/post_detail.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../models/feed_model.dart';
 import '../../widgets/navigation/back_app_bar.dart';
 import '../../widgets/sections/display/choices/choices_section.dart';
 import '../../widgets/sections/display/content_section.dart';
@@ -10,18 +11,12 @@ class PostDetail extends StatelessWidget {
   // 선택된 키워드를 저장할 변수
   // final List<String> keywords;
 
-  // 현재 게시물이 사용자 작성 게시물인지 여부
-  final bool isUserPost;
+  final FeedModel feedModel; // FeedModel을 받기 위한 변수
 
   // 임시로 설정한 키워드 리스트
   final List<String> keywords = ['여행', '음식', '기타', '바보'];
 
-  // const PostDetail({
-  //   Key? key,
-  //   required this.keywords, // 키워드 매개변수 추가
-  // }) : super(key: key);
-
-  PostDetail({super.key, required this.isUserPost});
+  PostDetail({Key? key, required this.feedModel}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -33,6 +28,8 @@ class PostDetail extends StatelessWidget {
     final String choiceBText = "선택 항목 B 텍스트";
     final String? imageAPath = 'assets/images/jjanggu.jpg';
     final String? imageBPath = null; // 이미지 경로가 없는 경우
+
+    final bool isMe = feedModel.isMe;
 
     return Scaffold(
       appBar: BackAppBar(),
@@ -51,7 +48,7 @@ class PostDetail extends StatelessWidget {
                 child: Column(
                   children: [
                     // 프로필 섹션
-                    ProfileSection(isUserPost: isUserPost), // 사용자 게시물 여부 전달
+                    ProfileSection(isMe: isMe), // 사용자 게시물 여부 전달
                     SizedBox(height: 10),
                     Divider(color: Color(0xffD9D9D9)),
 

--- a/gomintapa/lib/src/widgets/listitems/concern_list_item.dart
+++ b/gomintapa/lib/src/widgets/listitems/concern_list_item.dart
@@ -9,6 +9,7 @@ import '../../screens/post/post_detail.dart';
 
 class ConcernListItem extends StatelessWidget {
   final FeedModel item;
+
   const ConcernListItem(this.item, {super.key});
 
   @override
@@ -17,7 +18,7 @@ class ConcernListItem extends StatelessWidget {
       children: [
         CardSection(
           onTap: () {
-            Get.to(() => PostDetail());
+            Get.to(() => PostDetail(feedModel: item)); // FeedModel을 전달
           }, // onTap 콜백 설정
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.center,

--- a/gomintapa/lib/src/widgets/sections/display/profile_section.dart
+++ b/gomintapa/lib/src/widgets/sections/display/profile_section.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 
 class ProfileSection extends StatefulWidget {
-  final bool isUserPost; // 사용자 게시물 여부를 판단하는 변수
+  final bool isMe; // 사용자 게시물 여부를 판단하는 변수
 
-  const ProfileSection({super.key, required this.isUserPost});
+  const ProfileSection({super.key, required this.isMe});
 
   @override
   _ProfileSectionState createState() => _ProfileSectionState();
@@ -42,7 +42,7 @@ class _ProfileSectionState extends State<ProfileSection> {
               height: 40,
             ),
           ),
-        if (widget.isUserPost)
+        if (widget.isMe)
           PopupMenuButton<String>(
             color: Colors.white, // 배경색 흰색으로 설정
             onSelected: (value) {

--- a/gomintapa/lib/src/widgets/sections/display/profile_section.dart
+++ b/gomintapa/lib/src/widgets/sections/display/profile_section.dart
@@ -1,29 +1,74 @@
 import 'package:flutter/material.dart';
 
 class ProfileSection extends StatelessWidget {
-  const ProfileSection({super.key});
+  final bool isUserPost; // 사용자가 작성한 글인지 확인하는 변수
+
+  // 생성자
+  const ProfileSection({
+    Key? key,
+    required this.isUserPost,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return const Row(
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween, // 양 끝으로 정렬
       children: [
-        // 프로필 이미지
-        Image(
-          image: AssetImage('assets/images/default_profile.png'), // 이미지 경로 지정
-          width: 48, // 너비
-          height: 48, // 높이
-          fit: BoxFit.cover, // 이미지 맞춤 형태
-          alignment: Alignment.center, // 이미지 가운데 정렬
+        const Row(
+          children: [
+            // 프로필 이미지
+            Image(
+              image:
+                  AssetImage('assets/images/default_profile.png'), // 이미지 경로 지정
+              width: 48, // 너비
+              height: 48, // 높이
+              fit: BoxFit.cover, // 이미지 맞춤 형태
+              alignment: Alignment.center, // 이미지 가운데 정렬
+            ),
+            SizedBox(width: 20), // 이미지와 닉네임 사이 간격
+            // 사용자 이름
+            Text(
+              'username', // 실제 사용자 이름으로 대체
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
         ),
-        SizedBox(width: 20), // 이미지와 닉네임 사이 간격
-        // 사용자 이름
-        Text(
-          'username', // 실제 사용자 이름으로 대체
-          style: TextStyle(
-            fontSize: 16,
-            fontWeight: FontWeight.bold,
+        if (isUserPost) // 사용자가 작성한 글인 경우에만 표시
+          PopupMenuButton<String>(
+            onSelected: (String result) {
+              switch (result) {
+                case 'edit':
+                  // 수정 로직
+                  print('수정수정'); // 확인용
+                  break;
+                case 'delete':
+                  // 삭제 로직
+                  print('삭제삭제'); // 확인용
+                  break;
+                case 'resolve':
+                  // 고민해결로 바꾸는 로직
+                  print('고민해결!'); // 확인용
+                  break;
+              }
+            },
+            itemBuilder: (BuildContext context) => [
+              const PopupMenuItem<String>(
+                value: 'edit',
+                child: Text('수정'),
+              ),
+              const PopupMenuItem<String>(
+                value: 'delete',
+                child: Text('삭제'),
+              ),
+              const PopupMenuItem<String>(
+                value: 'resolve',
+                child: Text('고민해결로 바꾸기'),
+              ),
+            ],
           ),
-        ),
       ],
     );
   }

--- a/gomintapa/lib/src/widgets/sections/display/profile_section.dart
+++ b/gomintapa/lib/src/widgets/sections/display/profile_section.dart
@@ -1,73 +1,91 @@
 import 'package:flutter/material.dart';
 
-class ProfileSection extends StatelessWidget {
-  final bool isUserPost; // 사용자가 작성한 글인지 확인하는 변수
+class ProfileSection extends StatefulWidget {
+  final bool isUserPost; // 사용자 게시물 여부를 판단하는 변수
 
-  // 생성자
-  const ProfileSection({
-    Key? key,
-    required this.isUserPost,
-  }) : super(key: key);
+  const ProfileSection({super.key, required this.isUserPost});
+
+  @override
+  _ProfileSectionState createState() => _ProfileSectionState();
+}
+
+class _ProfileSectionState extends State<ProfileSection> {
+  bool isResolved = false; // 고민 해결 상태를 저장하는 변수
 
   @override
   Widget build(BuildContext context) {
     return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween, // 양 끝으로 정렬
       children: [
-        const Row(
-          children: [
-            // 프로필 이미지
-            Image(
-              image:
-                  AssetImage('assets/images/default_profile.png'), // 이미지 경로 지정
-              width: 48, // 너비
-              height: 48, // 높이
-              fit: BoxFit.cover, // 이미지 맞춤 형태
-              alignment: Alignment.center, // 이미지 가운데 정렬
-            ),
-            SizedBox(width: 20), // 이미지와 닉네임 사이 간격
-            // 사용자 이름
-            Text(
-              'username', // 실제 사용자 이름으로 대체
-              style: TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-          ],
+        // 프로필 이미지
+        const Image(
+          image: AssetImage('assets/images/default_profile.png'), // 이미지 경로 지정
+          width: 48, // 너비
+          height: 48, // 높이
+          fit: BoxFit.cover, // 이미지 맞춤 형태
+          alignment: Alignment.center, // 이미지 가운데 정렬
         ),
-        if (isUserPost) // 사용자가 작성한 글인 경우에만 표시
+        const SizedBox(width: 20), // 이미지와 닉네임 사이 간격
+        // 사용자 이름
+        const Text(
+          'username', // 실제 사용자 이름으로 대체
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        Spacer(), // 남은 공간을 차지하여 우측 정렬
+        if (isResolved)
+          Container(
+            child: Image(
+              image: AssetImage('assets/images/tangtang_selected.png'),
+              width: 40, // 이미지 크기 조정
+              height: 40,
+            ),
+          ),
+        if (widget.isUserPost)
           PopupMenuButton<String>(
-            onSelected: (String result) {
-              switch (result) {
+            color: Colors.white, // 배경색 흰색으로 설정
+            onSelected: (value) {
+              // 선택된 값에 따라 동작 수행
+              switch (value) {
                 case 'edit':
-                  // 수정 로직
-                  print('수정수정'); // 확인용
+                  // 수정 동작
                   break;
                 case 'delete':
-                  // 삭제 로직
-                  print('삭제삭제'); // 확인용
+                  // 삭제 동작
                   break;
-                case 'resolve':
-                  // 고민해결로 바꾸는 로직
-                  print('고민해결!'); // 확인용
+                case 'toggle':
+                  // 고민해결 상태를 토글할 때의 동작
+                  setState(() {
+                    isResolved = !isResolved;
+                  });
                   break;
               }
             },
-            itemBuilder: (BuildContext context) => [
-              const PopupMenuItem<String>(
-                value: 'edit',
-                child: Text('수정'),
-              ),
-              const PopupMenuItem<String>(
-                value: 'delete',
-                child: Text('삭제'),
-              ),
-              const PopupMenuItem<String>(
-                value: 'resolve',
-                child: Text('고민해결로 바꾸기'),
-              ),
-            ],
+            itemBuilder: (BuildContext context) {
+              return [
+                PopupMenuItem<String>(
+                  value: 'edit',
+                  child: Text('수정'),
+                ),
+                PopupMenuItem<String>(
+                  value: 'delete',
+                  child: Text('삭제'),
+                ),
+                PopupMenuItem<String>(
+                  value: 'toggle',
+                  child: Row(
+                    children: [
+                      isResolved ? Text('고민해결 완') : Text('고민해결 전'),
+                      Spacer(),
+                      isResolved
+                          ? Icon(Icons.check, color: Colors.green)
+                          : Icon(Icons.clear, color: Colors.red),
+                    ],
+                  ),
+                ),
+              ];
+            },
           ),
       ],
     );


### PR DESCRIPTION
- PopupMenuButton을 사용하여 사용자가 작성한 글에만 나타나게 함
  - 수정, 삭제, 고민해결 (**로직은 아직x**) @JJangMJ 해줘

- 고민해결 상태를 여부를 토글로 구현
  - 누르기 전
    ![Screenshot_20240725_033705](https://github.com/user-attachments/assets/b2c27c95-97ab-4ae6-8702-fd52a80e8dc7)
  - 누른 후
    ![Screenshot_20240725_033707](https://github.com/user-attachments/assets/7303cea4-948e-4729-a8b5-75bb01a9d1cc)

  - 고민 해결 버튼을 누르면 해결탕탕 이미지 나타남
    ![Screenshot_20240725_033712](https://github.com/user-attachments/assets/e423aac2-9bad-42c4-9097-b3a42f6a6a40)
  - 다시 버튼을 누르면? 아래와 같이 나타남
     ![Screenshot_20240725_033710](https://github.com/user-attachments/assets/b028111a-4157-4e16-a791-10c92371d9d1)

## ❗읽어줘!!! 로직 구현할 때 헷갈릴까봐 (민준오빠)❗
- **PostDetail**에서 **매개변수(isUserPost)** 받도록 해놨는데 **민준오빠 pr 머지**하고 나서 **충돌 생김**
  - **ConcernListItem에서 PostDetail로 이동하는 부분** 때문에
 
- 그래서 수정하다가 PostDetail에서 **FeedModel**을 불러와서 **원래 매개변수**로 해놨던 **isUserPost** 변수를 FeedModel에 있는 **isMe로 변경**