### PR TITLE
refactor: 투표율 차이 값 코드 분리 #99

### DIFF
--- a/gomintapa/lib/src/screens/feed/mak_feed_index.dart
+++ b/gomintapa/lib/src/screens/feed/mak_feed_index.dart
@@ -32,11 +32,25 @@ class _MakFeedIndexState extends State<MakFeedIndex> {
                 child: ListView(
                   children: [
                     MakListItem(
-                        onTap: () => _navigateToMyPage(context)), // 임시 설정
-                    MakListItem(onTap: () => _navigateToMyPage(context)),
-                    MakListItem(onTap: () => _navigateToMyPage(context)),
-                    MakListItem(onTap: () => _navigateToMyPage(context)),
-                    MakListItem(onTap: () => _navigateToMyPage(context)),
+                      onTap: () => _navigateToMyPage(context),
+                      initialVoteDifference: 1,
+                    ), // 임시 설정
+                    MakListItem(
+                      onTap: () => _navigateToMyPage(context),
+                      initialVoteDifference: 2,
+                    ),
+                    MakListItem(
+                      onTap: () => _navigateToMyPage(context),
+                      initialVoteDifference: 3,
+                    ),
+                    MakListItem(
+                      onTap: () => _navigateToMyPage(context),
+                      initialVoteDifference: 1,
+                    ),
+                    MakListItem(
+                      onTap: () => _navigateToMyPage(context),
+                      initialVoteDifference: 1,
+                    ),
                   ],
                 ),
               ),

--- a/gomintapa/lib/src/widgets/listitems/mak_list_item.dart
+++ b/gomintapa/lib/src/widgets/listitems/mak_list_item.dart
@@ -4,10 +4,35 @@ import 'package:gomintapa/src/widgets/cards/card_section.dart';
 import 'package:gomintapa/src/widgets/cards/card_top_section.dart';
 import 'package:gomintapa/src/widgets/texts/custom_text.dart';
 
-class MakListItem extends StatelessWidget {
-  final VoidCallback onTap; // onTap 콜백 추가
+class MakListItem extends StatefulWidget {
+  final VoidCallback onTap;
+  final int initialVoteDifference; // 초기 투표 차이 값
 
-  const MakListItem({super.key, required this.onTap});
+  const MakListItem({
+    super.key,
+    required this.onTap,
+    required this.initialVoteDifference,
+  });
+
+  @override
+  _MakListItemState createState() => _MakListItemState();
+}
+
+class _MakListItemState extends State<MakListItem> {
+  late int voteDifference; // 투표 차이 값을 저장할 상태 변수
+
+  @override
+  void initState() {
+    super.initState();
+    voteDifference = widget.initialVoteDifference; // 초기 투표 차이 값 설정
+  }
+
+  // 투표 차이 값을 업데이트하는 메서드
+  void updateVoteDifference(int newDifference) {
+    setState(() {
+      voteDifference = newDifference;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -15,12 +40,12 @@ class MakListItem extends StatelessWidget {
       children: [
         const SizedBox(height: 25),
         CardSection(
-          onTap: onTap, // onTap 콜백 설정
+          onTap: widget.onTap,
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               // 제목 영역
-              CardTopSection(
+              const CardTopSection(
                 title: '고민 제목',
               ),
               const SizedBox(height: 20),
@@ -28,7 +53,7 @@ class MakListItem extends StatelessWidget {
               Stack(
                 clipBehavior: Clip.none, // Stack의 클리핑 설정
                 children: [
-                  CardBottomSection(
+                  const CardBottomSection(
                     option1: '선택 1 내용',
                     option2: '선택 2 내용',
                   ),
@@ -45,7 +70,7 @@ class MakListItem extends StatelessWidget {
                         solidColorForMainText: Colors.red,
                         strokeColorForBorderText: Colors.white,
                         solidColorForBorderText: Colors.black,
-                        mainText: '0%',
+                        mainText: '${voteDifference}%', // 투표 차이 값을 전달
                         borderText: '차이',
                       ),
                     ),


### PR DESCRIPTION
## refacor 내용
### MakListItem
- StatefulWidget으로 변경
- 투표 차이 값(voteDifference)을 상태로 관리할 수 있도록 업데이트
- 투표 차이 값이 바뀌면 바뀐 새로운 값(newDifference)으로 업데이트하는 메서드(updateVoteDifference) 생성

### MakFeedIndex
- 각 MakListItem의 초기 투표 차이 값(initialVoteDifference)을 설정
- 투표 차이 값과, 페이지 이동 위치 임시로 설정