### PR TITLE
UI: 고민 카드 선택 영역 사다리꼴로 모양 변경

### DIFF
--- a/gomintapa/lib/src/widgets/cards/card_bottom_section.dart
+++ b/gomintapa/lib/src/widgets/cards/card_bottom_section.dart
@@ -13,23 +13,29 @@ class CardBottomSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
+    return Stack(
+      clipBehavior: Clip.none, // Stack의 클리핑 설정
+      //mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        TrapezoidOption(
-          text: option1,
-          color: Color.fromARGB(255, 255, 155, 155),
-          clipper: UpsideDownTrapezoidClipper(),
-          alignment: Alignment.centerLeft,
-          textAlign: TextAlign.left,
+        Padding(
+          padding: const EdgeInsets.only(right: 90.0), // 오른쪽에 10픽셀의 패딩 추가
+          child: TrapezoidOption(
+            text: option1,
+            color: Color.fromARGB(255, 255, 155, 155),
+            clipper: UpsideDownTrapezoidClipper(),
+            alignment: Alignment.centerLeft,
+            textAlign: TextAlign.center,
+          ),
         ),
-        const SizedBox(width: 10),
-        TrapezoidOption(
-          text: option2,
-          color: Color.fromARGB(255, 93, 177, 255),
-          clipper: BottomWideTrapezoidClipper(),
-          alignment: Alignment.centerRight,
-          textAlign: TextAlign.right,
+        Padding(
+          padding: const EdgeInsets.only(left: 90.0), // 왼쪽에 10픽셀의 패딩 추가
+          child: TrapezoidOption(
+            text: option2,
+            color: Color.fromARGB(255, 93, 177, 255),
+            clipper: BottomWideTrapezoidClipper(),
+            alignment: Alignment.centerRight,
+            textAlign: TextAlign.center,
+          ),
         ),
       ],
     );

--- a/gomintapa/lib/src/widgets/cards/card_bottom_section.dart
+++ b/gomintapa/lib/src/widgets/cards/card_bottom_section.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:gomintapa/src/widgets/cards/trapezoid_option.dart';
 
 class CardBottomSection extends StatelessWidget {
   final String option1;
@@ -15,41 +16,22 @@ class CardBottomSection extends StatelessWidget {
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        _buildOptionContainer(option1, Color.fromARGB(255, 255, 155, 155)),
-        const SizedBox(width: 10),
-        _buildOptionContainer(option2, Color.fromARGB(255, 93, 177, 255)),
-      ],
-    );
-  }
-
-  Widget _buildOptionContainer(String text, Color color) {
-    return Container(
-      width: 135,
-      height: 88,
-      decoration: BoxDecoration(
-        color: color,
-        borderRadius: BorderRadius.circular(5),
-      ),
-      alignment: Alignment.center,
-      child: Container(
-        width: 120,
-        height: 60,
-        padding: const EdgeInsets.all(5),
-        alignment: Alignment.center,
-        child: Text(
-          text,
-          maxLines: 2,
-          overflow: TextOverflow.ellipsis,
-          textAlign: TextAlign.center,
-          style: TextStyle(
-            color: Colors.white,
-            fontSize: 16,
-            fontFamily: 'Roboto',
-            fontWeight: FontWeight.w700,
-          ),
-          softWrap: true,
+        TrapezoidOption(
+          text: option1,
+          color: Color.fromARGB(255, 255, 155, 155),
+          clipper: UpsideDownTrapezoidClipper(),
+          alignment: Alignment.centerLeft,
+          textAlign: TextAlign.left,
         ),
-      ),
+        const SizedBox(width: 10),
+        TrapezoidOption(
+          text: option2,
+          color: Color.fromARGB(255, 93, 177, 255),
+          clipper: BottomWideTrapezoidClipper(),
+          alignment: Alignment.centerRight,
+          textAlign: TextAlign.right,
+        ),
+      ],
     );
   }
 }

--- a/gomintapa/lib/src/widgets/cards/card_section.dart
+++ b/gomintapa/lib/src/widgets/cards/card_section.dart
@@ -18,7 +18,7 @@ class CardSection extends StatelessWidget {
     return InkWell(
       onTap: onTap,
       child: Container(
-        width: 300,
+        width: 285,
         height: 150,
         decoration: BoxDecoration(
           color: backgroundColor,

--- a/gomintapa/lib/src/widgets/cards/card_top_section.dart
+++ b/gomintapa/lib/src/widgets/cards/card_top_section.dart
@@ -7,7 +7,7 @@ class CardTopSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: 285,
+      width: 235,
       height: 20,
       alignment: Alignment.center,
       child: Text(
@@ -17,7 +17,7 @@ class CardTopSection extends StatelessWidget {
         textAlign: TextAlign.center,
         style: TextStyle(
           color: Colors.black,
-          fontSize: 16,
+          fontSize: 20,
           fontFamily: 'Roboto',
           fontWeight: FontWeight.w800,
         ),

--- a/gomintapa/lib/src/widgets/cards/trapezoid_option.dart
+++ b/gomintapa/lib/src/widgets/cards/trapezoid_option.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+
+// 첫 번째 선택 항목
+class UpsideDownTrapezoidClipper extends CustomClipper<Path> {
+  @override
+  Path getClip(Size size) {
+    final Path path = Path();
+    path.moveTo(0, size.height); // 왼쪽 하단 모서리
+    path.lineTo(size.width, size.height); // 오른쪽 하단 모서리
+    path.lineTo(size.width - 65, 0); // 오른쪽 상단 모서리
+    path.lineTo(0, 0); // 왼쪽 상단 모서리
+    path.close(); // 경로 닫기
+    return path;
+  }
+
+  @override
+  bool shouldReclip(CustomClipper<Path> oldClipper) => false;
+}
+
+// 두 번째 선택 항목
+class BottomWideTrapezoidClipper extends CustomClipper<Path> {
+  @override
+  Path getClip(Size size) {
+    final Path path = Path();
+    path.moveTo(0, 0); // 왼쪽 상단 모서리
+    path.lineTo(140, 0); // 오른쪽 상단 모서리
+    path.lineTo(140, 88); // 오른쪽 하단 모서리
+    path.lineTo(140 - 80, 88); // 왼쪽 하단 모서리
+    path.close(); // 경로 닫기
+    return path;
+  }
+
+  @override
+  bool shouldReclip(CustomClipper<Path> oldClipper) => false;
+}
+
+class TrapezoidOption extends StatelessWidget {
+  final String text;
+  final Color color;
+  final CustomClipper<Path> clipper;
+  final Alignment alignment;
+  final TextAlign textAlign;
+
+  const TrapezoidOption({
+    super.key,
+    required this.text,
+    required this.color,
+    required this.clipper,
+    required this.alignment,
+    required this.textAlign,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipPath(
+      clipper: clipper,
+      child: Container(
+        width: 140,
+        height: 88,
+        color: color,
+        alignment: alignment,
+        child: Container(
+          width: 100,
+          height: 60,
+          padding: const EdgeInsets.all(10.0), // 텍스트 주변 여백
+          child: Text(
+            text,
+            maxLines: 2, // 최대 두 줄
+            overflow: TextOverflow.ellipsis, // 텍스트 길이가 영역을 초과할 경우 말 줄임표 처리
+            textAlign: textAlign,
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 16,
+              fontFamily: 'Roboto',
+              fontWeight: FontWeight.w700,
+            ),
+            softWrap: true, // 줄바꿈을 허용
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/gomintapa/lib/src/widgets/cards/trapezoid_option.dart
+++ b/gomintapa/lib/src/widgets/cards/trapezoid_option.dart
@@ -25,7 +25,7 @@ class BottomWideTrapezoidClipper extends CustomClipper<Path> {
     path.moveTo(0, 0); // 왼쪽 상단 모서리
     path.lineTo(140, 0); // 오른쪽 상단 모서리
     path.lineTo(140, 88); // 오른쪽 하단 모서리
-    path.lineTo(140 - 80, 88); // 왼쪽 하단 모서리
+    path.lineTo(140 - 75, 88); // 왼쪽 하단 모서리
     path.close(); // 경로 닫기
     return path;
   }

--- a/gomintapa/lib/src/widgets/listitems/concern_list_item.dart
+++ b/gomintapa/lib/src/widgets/listitems/concern_list_item.dart
@@ -23,6 +23,9 @@ class ConcernListItem extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
+              SizedBox(
+                height: 5,
+              ),
               // 제목 영역
               CardTopSection(
                 title: item.title,

--- a/gomintapa/lib/src/widgets/listitems/concern_list_item.dart
+++ b/gomintapa/lib/src/widgets/listitems/concern_list_item.dart
@@ -9,7 +9,6 @@ import '../../screens/post/post_detail.dart';
 
 class ConcernListItem extends StatelessWidget {
   final FeedModel item;
-
   const ConcernListItem(this.item, {super.key});
 
   @override

--- a/gomintapa/lib/src/widgets/listitems/mak_list_item.dart
+++ b/gomintapa/lib/src/widgets/listitems/mak_list_item.dart
@@ -48,7 +48,7 @@ class _MakListItemState extends State<MakListItem> {
               const CardTopSection(
                 title: '고민 제목',
               ),
-              const SizedBox(height: 20),
+              const SizedBox(height: 10),
               // 선택 항목 영역
               Stack(
                 clipBehavior: Clip.none, // Stack의 클리핑 설정

--- a/gomintapa/lib/src/widgets/listitems/mak_list_item.dart
+++ b/gomintapa/lib/src/widgets/listitems/mak_list_item.dart
@@ -44,6 +44,9 @@ class _MakListItemState extends State<MakListItem> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
+              const SizedBox(
+                height: 5,
+              ),
               // 제목 영역
               const CardTopSection(
                 title: '고민 제목',

--- a/gomintapa/lib/src/widgets/listitems/tang_list_item.dart
+++ b/gomintapa/lib/src/widgets/listitems/tang_list_item.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:gomintapa/src/widgets/cards/card_section.dart';
 import 'package:gomintapa/src/widgets/cards/card_top_section.dart';
+import 'package:gomintapa/src/widgets/cards/trapezoid_option.dart';
 
 class TangListItem extends StatelessWidget {
   final VoidCallback onTap; // onTap 콜백 추가
@@ -41,11 +42,11 @@ class TangListItem extends StatelessWidget {
                   // 이미지 아이콘
                   Padding(
                     padding:
-                        const EdgeInsets.only(right: 8.0), // 아이콘과 제목 사이의 간격
+                        const EdgeInsets.only(right: 5.0), // 아이콘과 제목 사이의 간격
                     child: Image.asset(
                       'assets/images/tangtang_selected.png',
-                      width: 45,
-                      height: 45,
+                      width: 42,
+                      height: 42,
                     ),
                   ),
                   // 제목 영역
@@ -56,78 +57,39 @@ class TangListItem extends StatelessWidget {
                   ),
                 ],
               ),
-              const SizedBox(height: 5),
               // 선택 항목 영역
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center, // 항목들 사이의 간격을 최소화
+              Stack(
+                //mainAxisAlignment: MainAxisAlignment.center, // 항목들 사이의 간격을 최소화
                 children: [
-                  // 첫 번째 선택 항목
-                  Container(
-                    width: 135,
-                    height: 78,
-                    decoration: BoxDecoration(
+                  Padding(
+                    padding: const EdgeInsets.only(right: 90.0),
+                    // 첫 번째 선택 항목
+                    child: TrapezoidOption(
+                      text: '선택 1 내용',
                       color: isOption1Winner
                           ? Color.fromARGB(255, 255, 155, 155) // 이긴 경우
                           : isOption2Winner
                               ? Color.fromARGB(255, 155, 155, 155) // 진 경우
                               : Color.fromARGB(255, 255, 155, 155), // 기본 색상
-                      borderRadius: BorderRadius.circular(5), // borderRadius 추가
-                    ),
-                    alignment: Alignment.center,
-                    child: Container(
-                      width: 120,
-                      height: 60,
-                      padding: const EdgeInsets.all(5), // 텍스트 주변 여백
-                      alignment: Alignment.center,
-                      child: Text(
-                        '선택 1 내용',
-                        maxLines: 2, // 최대 두 줄
-                        overflow: TextOverflow
-                            .ellipsis, // 텍스트 길이가 영역을 초과할 경우 말 줄임표 처리
-                        textAlign: TextAlign.center,
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontSize: 16,
-                          fontFamily: 'Roboto',
-                          fontWeight: FontWeight.w700,
-                        ),
-                        softWrap: true, // 줄바꿈을 허용
-                      ),
+                      clipper: UpsideDownTrapezoidClipper(), // 클리퍼 추가
+                      alignment: Alignment.centerLeft,
+                      textAlign: TextAlign.center,
                     ),
                   ),
-                  const SizedBox(width: 10),
                   // 두 번째 선택 항목
-                  Container(
-                    width: 135,
-                    height: 78,
-                    decoration: BoxDecoration(
+                  Padding(
+                    padding: const EdgeInsets.only(left: 90.0),
+                    // 첫 번째 선택 항목
+                    child: TrapezoidOption(
+                      text: '선택 2 내용선택 2 내용선택 2 내용선택 2 내용선택 2 내용',
                       color: isOption2Winner
                           ? Color.fromARGB(255, 93, 177, 255) // 이긴 경우
                           : isOption1Winner
                               ? Color.fromARGB(255, 155, 155, 155) // 진 경우
                               : Color.fromARGB(255, 93, 177, 255), // 기본 색상
-                      borderRadius: BorderRadius.circular(5), // borderRadius 추가
-                    ),
-                    alignment: Alignment.center,
-                    child: Container(
-                      width: 120,
-                      height: 60,
-                      padding: const EdgeInsets.all(5), // 텍스트 주변 여백
-                      alignment: Alignment.center,
-                      child: Text(
-                        '선택 2 내용',
-                        maxLines: 2, // 최대 두 줄
-                        overflow: TextOverflow
-                            .ellipsis, // 텍스트 길이가 영역을 초과할 경우 말 줄임표 처리
-                        textAlign: TextAlign.center,
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontSize: 16,
-                          fontFamily: 'Roboto',
-                          fontWeight: FontWeight.w700,
-                        ),
-                        softWrap: true, // 줄바꿈을 허용
-                      ),
+                      clipper: BottomWideTrapezoidClipper(), // 클리퍼 추가
+                      alignment: Alignment.centerRight,
+                      textAlign: TextAlign.center,
                     ),
                   ),
                 ],

--- a/gomintapa/lib/src/widgets/listitems/tang_list_item.dart
+++ b/gomintapa/lib/src/widgets/listitems/tang_list_item.dart
@@ -38,6 +38,7 @@ class TangListItem extends StatelessWidget {
             children: [
               // 이미지 아이콘과 제목 영역을 포함하는 Row
               Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   // 이미지 아이콘
                   Padding(
@@ -59,7 +60,6 @@ class TangListItem extends StatelessWidget {
               ),
               // 선택 항목 영역
               Stack(
-                //mainAxisAlignment: MainAxisAlignment.center, // 항목들 사이의 간격을 최소화
                 children: [
                   Padding(
                     padding: const EdgeInsets.only(right: 90.0),


### PR DESCRIPTION
## 변경 내용
### 사다리꼴 모양
- 도형 클리퍼를 활용하여 사다리꼴 모양 디자인
- 선택1을 회전시켰을 때 선택2와 동일한 모양

### 패딩 값 조정
- 영역의 가로, 세로 길이를 조정하지 않고 각각 왼쪽과 오른쪽에 패딩 값을 주어 간격을 맞춤
- Stack으로 레이아웃을 변경했을 때 겹치는 현상을 피하기 위함

### 텍스트 정렬
- 텍스트 영역은 각각 왼쪽과 오른쪽으로 정렬
- 텍스트는 가운데 정렬